### PR TITLE
don't require the whole lib to help installing from git

### DIFF
--- a/lib/scrapyard.rb
+++ b/lib/scrapyard.rb
@@ -2,8 +2,6 @@
 
 # namespace for scrapyard classes
 module Scrapyard
-  VERSION = '0.5.0'
-
   require_relative 'scrapyard/key'
   require_relative 'scrapyard/pack'
   require_relative 'scrapyard/yard'

--- a/lib/scrapyard/version.rb
+++ b/lib/scrapyard/version.rb
@@ -1,0 +1,3 @@
+module Scrapyard
+  VERSION = '0.5.0'
+end

--- a/scrapyard.gemspec
+++ b/scrapyard.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'lib/scrapyard'
+require_relative 'lib/scrapyard/version.rb'
 
 Gem::Specification.new do |s|
   s.name        = 'scrapyard'


### PR DESCRIPTION
previously, installing fresh from github would fail because `aws-sdk-s3` is required within scrapyard.

if we just require the version, the gemspec doesn't try to load `aws-sdk-s3`

```
Fetching gem metadata from https://rubygems.org/.......

[!] There was an error while loading `scrapyard.gemspec`: cannot load such file -- aws-sdk-s3
Does it try to require a relative path? That's been removed in Ruby 1.9. Bundler cannot continue.

 #  from /Users/michaelglass/.gem/ruby/2.3.7/bundler/gems/scrapyard-df5540c3866a/scrapyard.gemspec:3
 #  -------------------------------------------
 #
 >  require_relative 'lib/scrapyard'
 #
 #  -------------------------------------------
```