### PR TITLE
Allow Multiple SHA's referenced in keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Scrapyard is not yet published as a gem, so recommend installing it with bundler
 
 ```ruby
 # Gemfile
-gem 'scrapyard', git: 'https://github.com/dgtized/scrapyard', tag: 'v0.5.1', require: false
+gem 'scrapyard', git: 'https://github.com/dgtized/scrapyard', tag: 'v0.5.2', require: false
 ```
 
 ```bash

--- a/lib/scrapyard/key.rb
+++ b/lib/scrapyard/key.rb
@@ -28,7 +28,7 @@ module Scrapyard
     private
 
     def checksum(key)
-      key.gsub(/(#\([^}]+\))/) do |match|
+      key.gsub(/(#\([^)]+\))/) do |match|
         f = Pathname.new match[2..-2].strip
         if f.exist?
           log.debug "Including sha1 of #{f}"

--- a/lib/scrapyard/version.rb
+++ b/lib/scrapyard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Scrapyard
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/spec/lib/scrapyard/key_spec.rb
+++ b/spec/lib/scrapyard/key_spec.rb
@@ -16,13 +16,14 @@ RSpec.describe Scrapyard::Key do
   end
 
   context "checksum" do
+    let(:sha) { "f1d2d2f924e986ac86fdf7b36c94bcdf32beec15" }
     it "converts #(file) syntax to checksum" do
       expect(log).to receive(:debug).with(/Including sha1/)
       Tempfile.create("scrapyard") do |temp|
         temp.puts "foo"
         temp.close
         key = Scrapyard::Key.new("key-#(%s)" % [temp.path], "", log)
-        expect(key.to_s).to eq "key-f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"
+        expect(key.to_s).to eq "key-#{sha}"
       end
     end
 
@@ -30,6 +31,20 @@ RSpec.describe Scrapyard::Key do
       expect(log).to receive(:warn).with(/File missing-file does not exist/)
       key = Scrapyard::Key.new("key-#(missing-file)", "", log)
       expect(key.to_s).to eq "key-"
+    end
+
+    it "parses multiple checksums" do
+      expect(log).to receive(:debug).with(/Including sha1/).twice
+      Tempfile.create("scrap1") do |temp1|
+        temp1.puts "foo"
+        temp1.close
+        Tempfile.create("scrap2") do |temp2|
+          temp2.puts "foo"
+          temp2.close
+          key = Scrapyard::Key.new("key-#(%s)-#(%s)" % [temp1.path, temp2.path], "", log)
+          expect(key.to_s).to eq "key-#{sha}-#{sha}"
+        end
+      end
     end
   end
 

--- a/spec/lib/scrapyard/key_spec.rb
+++ b/spec/lib/scrapyard/key_spec.rb
@@ -6,6 +6,9 @@ require 'tempfile'
 
 RSpec.describe Scrapyard::Key do
   let(:log) { double }
+  def keygen(key)
+    Scrapyard::Key.new(key, "", log).to_s
+  end
 
   context ".to_keys" do
     it "adds suffixes to array" do
@@ -22,15 +25,13 @@ RSpec.describe Scrapyard::Key do
       Tempfile.create("scrapyard") do |temp|
         temp.puts "foo"
         temp.close
-        key = Scrapyard::Key.new("key-#(%s)" % [temp.path], "", log)
-        expect(key.to_s).to eq "key-#{sha}"
+        expect(keygen("key-#(%s)" % [temp.path])).to eq "key-#{sha}"
       end
     end
 
     it "recovers from missing checksum file with empty string" do
       expect(log).to receive(:warn).with(/File missing-file does not exist/)
-      key = Scrapyard::Key.new("key-#(missing-file)", "", log)
-      expect(key.to_s).to eq "key-"
+      expect(keygen("key-#(missing-file)")).to eq "key-"
     end
 
     it "parses multiple checksums" do
@@ -41,8 +42,8 @@ RSpec.describe Scrapyard::Key do
         Tempfile.create("scrap2") do |temp2|
           temp2.puts "foo"
           temp2.close
-          key = Scrapyard::Key.new("key-#(%s)-#(%s)" % [temp1.path, temp2.path], "", log)
-          expect(key.to_s).to eq "key-#{sha}-#{sha}"
+          expect(keygen("key-#(%s)-#(%s)" % [temp1.path, temp2.path])).
+            to eq "key-#{sha}-#{sha}"
         end
       end
     end
@@ -70,8 +71,7 @@ RSpec.describe Scrapyard::Key do
         "a/=b" => "a!!b"
       }.each do |example, result|
         expect(log).to receive(:warn).with(/Translated key to/) if example != result
-        expect(Scrapyard::Key.new(example, "", log).to_s).
-          to eq(result)
+        expect(keygen(example)).to eq(result)
       end
     end
   end


### PR DESCRIPTION
Fix key parsing so it supports multiple calls to `#()` sha syntax in a key.